### PR TITLE
Fix issue with inexact patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.1.9
+
+Fixes for patch version driver download issue. See https://bugs.chromium.org/p/chromium/issues/detail?id=1205107.
+
 # 12.1.8
 
 Fixes for macOS ChromeDriver download. If you are using a macOS and are

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriver-manager",
-  "version": "12.1.8",
+  "version": "12.1.9",
   "description": "A selenium server and browser driver manager for your end to end tests.",
   "scripts": {
     "format": "gulp format",

--- a/spec/binaries/chrome_xml_spec.ts
+++ b/spec/binaries/chrome_xml_spec.ts
@@ -91,12 +91,24 @@ describe('chrome xml reader', () => {
     });
   });
 
-  it('should get the 91.0.4472.101, 64-bit, m1 version (arch = arm64)', (done) => {
+  it('should get the 91.0.4472.101 (exactly specified), 64-bit, m1 version (arch = arm64)',
+     (done) => {
+       let chromeXml = new ChromeXml();
+       chromeXml.out_dir = out_dir;
+       chromeXml.ostype = 'Darwin';
+       chromeXml.osarch = 'arm64';
+       chromeXml.getUrl('91.0.4472.101').then((binaryUrl) => {
+         expect(binaryUrl.url).toContain('91.0.4472.101/chromedriver_mac64_m1.zip');
+         done();
+       });
+     });
+
+  it('should get the 91.0.4472.101 (by default), 64-bit, m1 version (arch = arm64)', (done) => {
     let chromeXml = new ChromeXml();
     chromeXml.out_dir = out_dir;
     chromeXml.ostype = 'Darwin';
     chromeXml.osarch = 'arm64';
-    chromeXml.getUrl('91.0.4472.101').then((binaryUrl) => {
+    chromeXml.getUrl('91.0.4472.124').then((binaryUrl) => {
       expect(binaryUrl.url).toContain('91.0.4472.101/chromedriver_mac64_m1.zip');
       done();
     });


### PR DESCRIPTION
Hey guys there is an issue with your patch (which I tried to apply to my project directly). Check out my new unit test for the broken use case. I get the Chrome version installed on the build machine via Windows registry key, then download the corresponding webdriver. But the patch versions do not always have webdriver builds, for example, current 91.0.4472 **Chrome** patch is 124 but chromedriver is 101. We want it to default to the latest patch in the case (or I did anyway).